### PR TITLE
Add support for Node 9 and above

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "module": "src/index.js",
   "engines": {
-    "node": "8",
+    "node": ">=8",
     "npm": ">=5"
   },
   "scripts": {


### PR DESCRIPTION
Without this you can't run npm install on a project using this package if you have Node 9.